### PR TITLE
Modifying Sel-Display.lua to allow for customization of colors and fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,3 @@ libs/rev1/*
 data/export/*
 sounds/*
 libs/closetCleaner.lua
-scripts/init.txt
-parse_augments.lua
-data/Farok/Farok-Globals (2).lua
-data/Farok/Farok Wishlist.txt

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ libs/rev1/*
 data/export/*
 sounds/*
 libs/closetCleaner.lua
+scripts/init.txt
+parse_augments.lua
+data/Farok/Farok-Globals (2).lua
+data/Farok/Farok Wishlist.txt

--- a/data/Selindrile/Selindrile-Globals.lua
+++ b/data/Selindrile/Selindrile-Globals.lua
@@ -16,6 +16,14 @@ state.DisplayMode = M(true, 'Display Mode') --Set this to false if you don't wan
 --Uncomment the settings below and change the numbers if you want to move the display to a custom location.
 --displayx = 3
 --displayy = 1062
+--If you want to use a custom font or colors, uncomment the settings below
+--custom_font = 'Times New Roman'
+--state.DisplayColors = {
+    -- h='\\cs(255, 0, 0)', -- Red for active booleans and non-default modals
+    -- w='\\cs(255,255,255)', -- White for labels and default modals
+    -- n='\\cs(192,192,192)', -- White for labels and default modals
+    -- s='\\cs(96,96,96)' -- Gray for inactive booleans
+--}
 
 --Options for automation.
 state.ReEquip = M(true, 'ReEquip Mode') --Set this to false if you don't want it to your current Weapon sets (sets.weapons by default) when you aren't wearing any weapons.

--- a/libs/Sel-Display.lua
+++ b/libs/Sel-Display.lua
@@ -46,10 +46,16 @@ function init_job_states(job_bools,job_modes)
 	else
 		x,y = 0, settings["ui_y_res"]-17 -- -285, -18
 	end
+
+	local font = 'Arial'
+
+	if custom_font then
+		font = custom_font
+	end
 	
     stateBox = texts.new()
     stateBox:pos(x,y)
-    stateBox:font('Arial')--Arial
+    stateBox:font(font)--Arial
     stateBox:size(12)
     stateBox:bold(true)
     stateBox:bg_alpha(0)--128
@@ -79,6 +85,9 @@ function update_job_states()
         n='\\cs(192,192,192)', -- White for labels and default modals
         s='\\cs(96,96,96)' -- Gray for inactive booleans
     }
+    if state.DisplayColors then
+		clr = state.DisplayColors
+	end
 
     local info = {}
     local orig = {}


### PR DESCRIPTION
Adds check for a custom `state.DisplayColors` variable that will override the colors table to allow customization. Also adds a global `custom_font` variable to allow customization. Updated Selindrile-Globals.lua with commented out example.