### PR TITLE
BLU.lua: add unbridled_ready() check to check_buff()

### DIFF
--- a/data/BLU.lua
+++ b/data/BLU.lua
@@ -472,9 +472,11 @@ function check_buff()
 		local spell_recasts = windower.ffxi.get_spell_recasts()
 		for i in pairs(buff_spell_lists['Auto']) do
 			if not buffactive[buff_spell_lists['Auto'][i].Buff] and (buff_spell_lists['Auto'][i].When == 'Always' or (buff_spell_lists['Auto'][i].When == 'Combat' and (player.in_combat or being_attacked)) or (buff_spell_lists['Auto'][i].When == 'Engaged' and player.status == 'Engaged') or (buff_spell_lists['Auto'][i].When == 'Idle' and player.status == 'Idle') or (buff_spell_lists['Auto'][i].When == 'OutOfCombat' and not (player.in_combat or being_attacked))) and spell_recasts[buff_spell_lists['Auto'][i].SpellID] < latency and silent_can_use(buff_spell_lists['Auto'][i].SpellID) then
-				windower.chat.input('/ma "'..buff_spell_lists['Auto'][i].Name..'" <me>')
-				tickdelay = os.clock() + 2
-				return true
+				if not unbridled_spells:contains(buff_spell_lists['Auto'][i].Name) or unbridled_ready() then
+					windower.chat.input('/ma "'..buff_spell_lists['Auto'][i].Name..'" <me>')
+					tickdelay = os.clock() + 2
+					return true
+				end
 			end
 		end
 	else


### PR DESCRIPTION
Fixes a bug where check_buff() would repeatedly attempt to recast Mighty Guard while Unbridled Learning is on cooldown, preventing all default_tick() actions.