### PR TITLE
Support `sets.precast.RA.WeaponSet`

### DIFF
--- a/data/RNG.lua
+++ b/data/RNG.lua
@@ -185,6 +185,12 @@ function job_post_precast(spell, spellMap, eventArgs)
 					equip(sets.precast.RA.Flurry2)
 				end
 			end
+		else
+			if sets.precast.RA[state.Weapons.value] then
+				equip(sets.precast.RA[state.Weapons.value])
+			else
+				equip(sets.precast.RA)
+			end
 		end
 
 		if statusammo then


### PR DESCRIPTION
There is already support for `sets.precast.RA['Weapon Set'].Flurry` and `.Flurry2`, but unbuffed sets are not supported.