### PR TITLE
Fix cancel Stoneskin while asleep

### DIFF
--- a/data/User/User-Globals.lua
+++ b/data/User/User-Globals.lua
@@ -8,7 +8,7 @@ conserveshadows = false
 state.ReEquip 		  		= M(true, 'ReEquip Mode')		 --Set this to false if you don't want to equip your current Weapon set when you aren't wearing any weapons.
 state.AutoArts 		  		= M(true, 'AutoArts') 		 --Set this to false if you don't want to automatically try to keep up Solace/Arts.
 state.AutoLockstyle	 	    = M(true, 'AutoLockstyle Mode') --Set this to false if you don't want gearswap to automatically lockstyle on load and weapon change.
-state.CancelStoneskin 		= M(true, 'Cancel Stone Skin') --Set this to false if you don't want to automatically cancel stoneskin when you're slept.
+state.CancelStoneskin 		= M(true, 'Auto Cancel Stoneskin') --Set this to false if you don't want to automatically cancel stoneskin when you're slept.
 state.SkipProcWeapons 		= M(true, 'Skip Proc Weapons') --Set this to false if you want to display weapon sets fulltime rather than just Aby/Voidwatch.
 state.NotifyBuffs	  		= M(false, 'Notify Buffs') 	 --Set this to true if you want to notify your party when you recieve a specific buff/debuff. (List Below)
 

--- a/libs/Sel-Include.lua
+++ b/libs/Sel-Include.lua
@@ -2441,6 +2441,8 @@ function buff_change(buff, gain)
 			internal_enable_set("Doom")
 		end
 	elseif buff == 'sleep' or buff == 'Lullaby' then
+		if  state.CancelStoneskin.value then
+			send_command('cancel stoneskin')
 		if gain then
 			if item_equippable("Sacrifice Torque") and pet.isvalid then
 				internal_disable_set({neck="Sacrifice Torque"}, "Sleep")


### PR DESCRIPTION
I noticed that stoneskin was not cancelled while being assleep (equip of the gear was working). In addition I adjusted naming in the User-Global to match the include file.
