### PR TITLE
Missing aja return in BLM elemental function

### DIFF
--- a/data/BLM.lua
+++ b/data/BLM.lua
@@ -381,6 +381,7 @@ function handle_job_elemental(command, target)
 		return true
 	elseif command == 'aja' then
 		windower.chat.input('/ma "'..data.elements.nukega_of[state.ElementalMode.value]..'ja" '..target..'')
+		return true
 	end
 	return false
 end


### PR DESCRIPTION
- Aja spells are caught but the function still falls back to the general handler, which then errors due to no -aja case